### PR TITLE
Add missing function call in update_timslots task

### DIFF
--- a/back/courses/tasks.py
+++ b/back/courses/tasks.py
@@ -18,7 +18,7 @@ def update_timeslots(days_forward):
     """
     today = timezone.now().date()
 
-    Timeslot.objects.filter(start__lte=today - datetime.timedelta(60))
+    Timeslot.objects.filter(start__lte=today - datetime.timedelta(60)).delete()
 
     for i in range(days_forward):
         get_schedule(today + datetime.timedelta(days=i))


### PR DESCRIPTION
I forgot the call to Query.delete in order to delete old timeslots before fetching new ones