### PR TITLE
Add posts on course details page

### DIFF
--- a/back/courses/models.py
+++ b/back/courses/models.py
@@ -119,5 +119,9 @@ class Resource(models.Model):
     date = models.DateTimeField()
     file = models.FileField("Fichier", upload_to="ressources", null=True, blank=True)
     post = models.ForeignKey(
-        "news.Post", verbose_name="post", on_delete=models.SET_NULL, null=True
+        "news.Post",
+        verbose_name="post",
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="resource",
     )

--- a/back/courses/serializers.py
+++ b/back/courses/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import Course, Group, Teacher, Timeslot
+from .models import Course, Group, Resource, Teacher, Timeslot
 
 
 class TeacherSerializer(serializers.HyperlinkedModelSerializer):
@@ -62,4 +62,17 @@ class TimeslotSerializer(serializers.HyperlinkedModelSerializer):
             "course_groups",
             "course_name",
             "place",
+        ]
+
+
+class ResourceSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Resource
+        fields = [
+            "id",
+            "name",
+            "author",
+            "date",
+            "file",
+            "post",
         ]

--- a/back/courses/templates/courses/view_course.html
+++ b/back/courses/templates/courses/view_course.html
@@ -93,7 +93,19 @@
 
         </div><!--End of Main Content-->
 
+        <div id="posts">
+            <!--Posts are rendered here by react-->
+        </div>
+
     </div><!--End of Content-->
+
+    <!--Scripts-->
+    <script src="{% url 'reverse_js' %}" type="text/javascript"></script> <!--Put this script before any react script to be able to reverse django urls in react-->
+    <script>
+        const courseId = {{course.pk}};
+        window.react_mount = document.getElementById("posts");
+    </script>
+    <script src="{% static 'react/course_posts.bundle.js' %}"></script>
 
 </body><!--End of Body-->
 

--- a/back/courses/templates/courses/view_course.html
+++ b/back/courses/templates/courses/view_course.html
@@ -93,6 +93,7 @@
 
         </div><!--End of Main Content-->
 
+        <h4 class="page-title">Posts</h4>
         <div id="posts">
             <!--Posts are rendered here by react-->
         </div>

--- a/back/courses/views.py
+++ b/back/courses/views.py
@@ -9,9 +9,14 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from social.models import Student
 
-from .models import Course, CourseDepartment, Enrolment, Group, Timeslot
+from .models import Course, CourseDepartment, Enrolment, Group, Resource, Timeslot
 from .scrapper import get_schedule
-from .serializers import CourseSerializer, GroupSerializer, TimeslotSerializer
+from .serializers import (
+    CourseSerializer,
+    GroupSerializer,
+    ResourceSerializer,
+    TimeslotSerializer,
+)
 
 
 class ListCourseDepartments(views.APIView):
@@ -95,6 +100,12 @@ class TimeslotViewSet(viewsets.ModelViewSet):
                 )
 
         return queryset.order_by("start", "pk")
+
+
+class ResourceViewSet(viewsets.ModelViewSet):
+    queryset = Resource.objects.all().order_by("date", "name")
+    serializer_class = ResourceSerializer
+    http_method_names = ["get"]
 
 
 @login_required

--- a/back/news/serializers.py
+++ b/back/news/serializers.py
@@ -199,6 +199,7 @@ class PostSerializer(serializers.HyperlinkedModelSerializer):
             "id",
             "can_edit",
             "user_author_url",
+            "resource",
         ]
 
 

--- a/back/news/serializers.py
+++ b/back/news/serializers.py
@@ -1,3 +1,4 @@
+from courses.serializers import ResourceSerializer
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from rest_framework import serializers
@@ -172,6 +173,8 @@ class PostSerializer(serializers.HyperlinkedModelSerializer):
 
     def get_user_author_url(self, obj):
         return reverse("social:profile_viewed", args=(obj.author.user.pk,))
+
+    resource = ResourceSerializer(many=True, read_only=True)
 
     class Meta:
         model = Post

--- a/back/news/tests.py
+++ b/back/news/tests.py
@@ -10,7 +10,7 @@ from rest_framework.test import APITestCase
 from social.models import Club, Membership, Student
 
 from .models import Comment, Event, Participation, Post, Shotgun
-from .views import posts
+from .views import comment_post
 
 
 class ShotgunModelTest(TestCase):
@@ -383,7 +383,7 @@ class CommentViewsTest(TestCase):
             separators=(",", ":"),
         ).encode("utf-8")
         comment_request.user = self.comment_user
-        response = posts(comment_request)
+        response = comment_post(comment_request, self.post.pk)
         self.assertEqual(response.status_code, 201)
         retrieved_comment = Comment.objects.get(post=self.post)
         self.assertEqual(retrieved_comment.content, "Some test comment from a student")
@@ -431,7 +431,7 @@ class CommentViewsTest(TestCase):
             separators=(",", ":"),
         ).encode("utf-8")
         comment_request.user = self.comment_user
-        response = posts(comment_request)
+        response = comment_post(comment_request, self.post.pk)
         self.assertEqual(response.status_code, 201)
         retrieved_comment = Comment.objects.get(post=self.post)
         self.assertEqual(retrieved_comment.content, "Some test comment from a club")

--- a/back/news/urls.py
+++ b/back/news/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
         "post/create/<int:event_id>", views.post_create, name="post_create_with_origin"
     ),
     path("post/<int:post_id>/<str:action>", views.post_like, name="post_like"),
+    path("comment/add/<int:post_id>/", views.comment_post, name="comment_post"),
     path(
         "comment/delete/<int:comment_id>/",
         views.delete_comment,

--- a/back/news/views.py
+++ b/back/news/views.py
@@ -22,12 +22,14 @@ def posts(request):
     if request.method == "GET":
         return render(request, "news/posts.html")
 
-    elif request.method == "POST":
+
+@login_required
+def comment_post(request, post_id):
+    if request.method == "POST":
         student = get_object_or_404(Student, user__id=request.user.id)
         data = json.loads(request.body.decode("utf-8"))
-        commented_post_id = data["post"]
-        commented_post = get_object_or_404(Post, id=commented_post_id)
-        filled_form = CommentForm(commented_post_id, student.user.id, data=data)
+        commented_post = get_object_or_404(Post, id=post_id)
+        filled_form = CommentForm(post_id, student.user.id, data=data)
 
         if filled_form.is_valid():
             new_comment = filled_form.save(commit=False)
@@ -37,6 +39,8 @@ def posts(request):
             new_comment.save()
             return HttpResponse(status=201)
         return HttpResponse(status=500)
+    else:
+        return HttpResponse(status=400)
 
 
 class PostViewSet(viewsets.ModelViewSet):

--- a/back/upont/static/css/styles.css
+++ b/back/upont/static/css/styles.css
@@ -1309,6 +1309,22 @@ a.text-green:hover{
     height: 0;
 }
 
+.news-card-resource{
+    /* Positionning */
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 0.2rem 0.5rem;
+}
+
+.resource-name{
+    font-weight: bold;
+}
+.resource-download{
+    margin-left: auto;
+}
+
 /*-------------------------------------------------*/
 /*------------------- NAV OF NEWS -----------------*//*      A REVOIR      */
 /*-------------------------------------------------*/

--- a/back/upont/urls.py
+++ b/back/upont/urls.py
@@ -18,6 +18,7 @@ from courses.views import (
     CourseViewSet,
     GroupViewSet,
     ListCourseDepartments,
+    ResourceViewSet,
     TimeslotViewSet,
 )
 from django.conf import settings
@@ -78,6 +79,7 @@ router.register(r"events", EventViewSet, basename="event")
 router.register(r"courses", CourseViewSet, basename="course")
 router.register(r"groups", GroupViewSet, basename="group")
 router.register(r"timeslots", TimeslotViewSet, basename="timeslot")
+router.register(r"resources", ResourceViewSet, basename="resource")
 
 urlpatterns += [
     path(

--- a/back/upont/urls.py
+++ b/back/upont/urls.py
@@ -73,7 +73,7 @@ else:
 
 router = routers.DefaultRouter()
 router.register(r"students", StudentViewSet)
-router.register(r"posts", PostViewSet)
+router.register(r"posts", PostViewSet, basename="post")
 router.register(r"events", EventViewSet, basename="event")
 router.register(r"courses", CourseViewSet, basename="course")
 router.register(r"groups", GroupViewSet, basename="group")

--- a/react/src/components/commentForm.jsx
+++ b/react/src/components/commentForm.jsx
@@ -6,6 +6,7 @@ export default class CommentForm extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      mode: props.mode,
       content: '',
       post_id: props.post_id,
       club: '',
@@ -35,7 +36,8 @@ export default class CommentForm extends React.Component {
 
   handleSubmit(event) {
     event.preventDefault();
-    const url = '';
+    // eslint-disable-next-line no-undef
+    const url = Urls['news:comment_post'](this.state.post_id);
     const csrfmiddlewaretoken = getCookie('csrftoken');
     const requestOptions = {
       method: 'POST',
@@ -101,7 +103,7 @@ export default class CommentForm extends React.Component {
       </div>
     );
 
-    if (options.length > 1) {
+    if (this.state.mode === 'social' && options.length > 1) {
       // The user is member of at least one club, he/she can choose to comment as a club
       const field2 = (
         <div className="">
@@ -139,6 +141,7 @@ export default class CommentForm extends React.Component {
   }
 }
 CommentForm.propTypes = {
+  mode: PropTypes.string.isRequired,
   post_id: PropTypes.number.isRequired,
   refreshPost: PropTypes.func.isRequired,
 };

--- a/react/src/components/posts.jsx
+++ b/react/src/components/posts.jsx
@@ -372,6 +372,10 @@ class Posts extends React.Component {
     if (mode === 'social') {
       // eslint-disable-next-line no-undef
       url = `${Urls.postList()}?mode=social`;
+    } else if (mode === 'course') {
+      const { courseId } = props;
+      // eslint-disable-next-line no-undef
+      url = `${Urls.postList()}?mode=course&course_id=${courseId}`;
     }
     this.state = {
       posts: [],

--- a/react/src/components/posts.jsx
+++ b/react/src/components/posts.jsx
@@ -12,6 +12,7 @@ import Comment from './comment';
 import CommentForm from './commentForm';
 import { addZero } from './utils/utils';
 import { getCookie } from './utils/csrf';
+import Resource from './resource';
 
 function postLogo(state) {
   if (state.post.club) {
@@ -330,6 +331,9 @@ class Post extends React.Component {
             {this.show_event_button()}
           </div>
           {postIllustration(this.state)}
+          {this.state.post.resource.map((resource) => (
+            <Resource resource={resource} key={resource.id} />
+          ))}
           <div className="news-card-actions">
             <span>
               {this.post_like_button()} {this.state.post.total_likes}{' '}

--- a/react/src/components/posts.jsx
+++ b/react/src/components/posts.jsx
@@ -107,8 +107,10 @@ function postIllustration(state) {
 class Post extends React.Component {
   constructor(props) {
     super(props);
+    const { mode } = props;
     this.state = {
       post: props.post,
+      mode,
       numberOfCommentsShown: 1,
     };
     this.refresh = this.refresh.bind(this);
@@ -356,6 +358,7 @@ class Post extends React.Component {
               post_id={this.state.post.id}
               currentStudent={this.props.currentStudent}
               refreshPost={this.refresh}
+              mode={this.state.mode}
             />
           </div>
         </div>
@@ -378,6 +381,7 @@ class Posts extends React.Component {
       url = `${Urls.postList()}?mode=course&course_id=${courseId}`;
     }
     this.state = {
+      mode,
       posts: [],
       next_url: url,
       more_exist: true,
@@ -443,6 +447,7 @@ class Posts extends React.Component {
               post={post}
               key={post.id}
               currentStudent={this.state.currentStudent}
+              mode={this.state.mode}
             />
           ))}
         </div>

--- a/react/src/components/posts.jsx
+++ b/react/src/components/posts.jsx
@@ -367,10 +367,15 @@ class Post extends React.Component {
 class Posts extends React.Component {
   constructor(props) {
     super(props);
+    const { mode } = props;
+    let url;
+    if (mode === 'social') {
+      // eslint-disable-next-line no-undef
+      url = `${Urls.postList()}?mode=social`;
+    }
     this.state = {
       posts: [],
-      // eslint-disable-next-line no-undef
-      next_url: Urls.postList(),
+      next_url: url,
       more_exist: true,
       currentStudent: '',
     };

--- a/react/src/components/resource.jsx
+++ b/react/src/components/resource.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function Resource(props) {
+  const { resource } = props;
+
+  return (
+    <div className="news-card-resource">
+      <div className="resource-name flex-column">{resource.name}</div>
+      <a
+        className="resource-download"
+        href={resource.file}
+        download={resource.name}
+      >
+        <button className="button green-button" type="button">
+          Télécharger
+        </button>
+      </a>
+    </div>
+  );
+}
+
+Resource.propTypes = {
+  resource: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    file: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/react/src/pages/course_posts.js
+++ b/react/src/pages/course_posts.js
@@ -1,0 +1,10 @@
+import ReactDOM from 'react-dom';
+import React from 'react';
+import Posts from '../components/posts';
+
+ReactDOM.render(
+  // courseId if define in django template
+  // eslint-disable-next-line no-undef
+  <Posts mode="course" courseId={courseId} />,
+  window.react_mount,
+);

--- a/react/src/pages/posts.js
+++ b/react/src/pages/posts.js
@@ -2,4 +2,4 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import Posts from '../components/posts';
 
-ReactDOM.render(<Posts />, window.react_mount);
+ReactDOM.render(<Posts mode="social" />, window.react_mount);


### PR DESCRIPTION
# Features
 - Show the posts related to a course on its details page
 - Posts are shown in descending order of (Number of likes - Number of dislikes)
 - Resources are show with the post they are related to

# To test
- Posts features on course details page
- Posts features on news page to check if nothing has been brocken