### PR TITLE
Fix emploidutemps scrapper

### DIFF
--- a/back/courses/scrapper.py
+++ b/back/courses/scrapper.py
@@ -49,7 +49,7 @@ def get_schedule(date):
         department = infos[1].text.strip()
         emplacement = infos[2].text.split("-")[0].strip()
         group = infos[3].text.strip()
-        group_number = int(group[3]) if group else None
+        group_number = int(group[3]) if (group and group.isdigit()) else None
         if "-" not in infos[4].text:
             acronym = ""
             # name = infos[4].text.strip()


### PR DESCRIPTION
This PR solve issue #169 

The error came from a group number that wasn't a number.

# Test
Add some courses to your database. Then run manually the tasks to update timeslots:
```
$ docker-compose exec back /bin/bash
# python3 manage.py shell
```
```python
>>> from Courses.tasks import update_timeslots
>>> update_timeslots.delay(200)
```

Where 200 is  the number of day to update forward.

The expected behavior is that the timeslots of the courses add up to the database automatically